### PR TITLE
Don't require mako

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='bitmapist',
       author="amix",
       author_email="amix@amix.dk",
       url="http://www.amix.dk/",
-      install_requires = ['redis>=2.7.1', 'mako', 'python-dateutil'],
+      install_requires = ['redis>=2.7.1', 'python-dateutil'],
       classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Since mako is only required for bitmapist.cohort it makes sense to maintain it as an optional dependency
