### PR TITLE
Cohorts: Average column should include the zero entry

### DIFF
--- a/bitmapist/cohort/tmpl/table_data.mako
+++ b/bitmapist/cohort/tmpl/table_data.mako
@@ -96,9 +96,8 @@
                 total = 0.0
                 for row_data in dates_data:
                     prct = row_data[i]
-                    if prct:
-                        cnts += 1
-                        total += prct
+                    cnts += 1
+                    total += prct
 
                 if cnts > 0:
                     avg = total / cnts


### PR DESCRIPTION
For some reason, we seem to skip the zero-entry when calculating the averages for a cohort column. We should not do this as this isn't correct.

Twist report:
https://twist.com/a/1585/ch/296215/t/1972753