### PR TITLE
feat: Change the default for number of results

### DIFF
--- a/bitmapist/cohort/__init__.py
+++ b/bitmapist/cohort/__init__.py
@@ -80,7 +80,7 @@ def render_html_form(action_url,
                      selections2=None, selections2b=None,
                      time_group='days',
                      select1=None, select1b=None, select2=None, select2b=None,
-                     as_precent=1, num_results=25, num_of_rows=12):
+                     as_precent=1, num_results=30, num_of_rows=12):
     """
     Render a HTML form that can be used to query the data in bitmapist.
 
@@ -125,7 +125,7 @@ def render_html_form(action_url,
 
 def render_html_data(dates_data,
                      as_precent=True, time_group='days',
-                     num_results=25, num_of_rows=12):
+                     num_results=30, num_of_rows=12):
     """
     Render's data as HTML, inside a TABLE element.
 
@@ -144,7 +144,7 @@ def render_html_data(dates_data,
 
 def render_csv_data(dates_data,
                     as_precent=True, time_group='days',
-                    num_results=25, num_of_rows=12):
+                    num_results=30, num_of_rows=12):
     """
     Render's data as CSV.
     """
@@ -161,7 +161,7 @@ def render_csv_data(dates_data,
 
 def get_dates_data(select1, select1b, select2, select2b,
                    time_group='days', system='default',
-                   as_precent=1, num_results=25, num_of_rows=12):
+                   as_precent=1, num_results=30, num_of_rows=12):
     """
     Fetch the data from bitmapist.
 

--- a/bitmapist/cohort/tmpl/form_data.mako
+++ b/bitmapist/cohort/tmpl/form_data.mako
@@ -46,10 +46,14 @@
         <dd>
             Number of results:
             <select name="num_results">
-                <option value="5" ${ 'selected="selected"' if num_results == 5 else '' }>5</option>
-                <option value="25" ${ 'selected="selected"' if num_results == 25 else '' }>25</option>
-                <option value="50" ${ 'selected="selected"' if num_results == 50 else '' }>50</option>
-                <option value="100" ${ 'selected="selected"' if num_results == 100 else '' }>100</option>
+                <option value="7" ${ 'selected="selected"' if num_results == 7 else '' }>5</option>
+                <option value="30" ${ 'selected="selected"' if num_results == 30 else '' }>5</option>
+                <option value="" disabled="disabled">----</option>
+                <option value="12" ${ 'selected="selected"' if num_results == 12 else '' }>5</option>
+                <option value="24" ${ 'selected="selected"' if num_results == 24 else '' }>5</option>
+                <option value="" disabled="disabled">----</option>
+                <option value="52" ${ 'selected="selected"' if num_results == 52 else '' }>5</option>
+                <option value="104" ${ 'selected="selected"' if num_results == 104 else '' }>5</option>
             </select>
         </dd>
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='bitmapist',
-      version='3.103',
+      version='3.104',
       author="amix",
       author_email="amix@amix.dk",
       url="http://www.amix.dk/",


### PR DESCRIPTION
## Context

It would be useful to group the number of results in common counts, i.e.:

* 7/30 (days)
* 12/24 (months)
* 52 (weeks)

This PR implements this instead of generic counts (e.g., 5, 25, 50, 100).