### PR TITLE
fix: Set select1b select2b to be optional

### DIFF
--- a/bitmapist/cohort/__init__.py
+++ b/bitmapist/cohort/__init__.py
@@ -159,7 +159,8 @@ def render_csv_data(dates_data,
 
 # --- Data rendering
 
-def get_dates_data(select1, select1b, select2, select2b,
+def get_dates_data(select1, select2,
+                   select1b=None, select2b=None,
                    time_group='days', system='default',
                    as_precent=1, num_results=30, num_of_rows=12):
     """


### PR DESCRIPTION
## Context

`select1b` and `select2b` should be optional else. If they aren't, some of the examples will fail.