### PR TITLE
Replace all uses of utcnow with tz-aware datetimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ Can be installed very easily via:
 Setting things up:
 
 ```python
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from bitmapist import setup_redis, delete_all_events, mark_event,\
                       MonthEvents, WeekEvents, DayEvents, HourEvents,\
                       BitOpAnd, BitOpOr
 
-now = datetime.utcnow()
-last_month = datetime.utcnow() - timedelta(days=30)
+now = datetime.now(tz=timezone.utc)
+last_month = now - timedelta(days=30)
 ```
 
 Mark user 123 as active and has played a song:

--- a/bitmapist/__init__.py
+++ b/bitmapist/__init__.py
@@ -210,8 +210,8 @@ def _mark(
         track_hourly = TRACK_HOURLY
     if track_unique is None:
         track_unique = TRACK_UNIQUE
-
-    now = now or datetime.now(tz=timezone.utc)
+    if now is None:
+        now = datetime.now(tz=timezone.utc)
 
     obj_classes: list[
         type[MonthEvents]

--- a/bitmapist/__init__.py
+++ b/bitmapist/__init__.py
@@ -473,7 +473,9 @@ class YearEvents(GenericPeriodEvents):
     """
 
     @classmethod
-    def from_date(cls, event_name, dt: Optional[date | datetime] = None, system="default"):
+    def from_date(
+        cls, event_name, dt: Optional[date | datetime] = None, system="default"
+    ):
         dt = dt or datetime.now(tz=timezone.utc)
         return cls(event_name, dt.year, system=system)
 
@@ -507,7 +509,9 @@ class MonthEvents(GenericPeriodEvents):
     """
 
     @classmethod
-    def from_date(cls, event_name, dt: Optional[date | datetime] = None, system="default"):
+    def from_date(
+        cls, event_name, dt: Optional[date | datetime] = None, system="default"
+    ):
         dt = dt or datetime.now(tz=timezone.utc)
         return cls(event_name, dt.year, dt.month, system=system)
 
@@ -528,7 +532,9 @@ class MonthEvents(GenericPeriodEvents):
 
     def period_end(self):
         _, day = calendar.monthrange(self.year, self.month)
-        return datetime(self.year, self.month, day, 23, 59, 59, 999999, tzinfo=timezone.utc)
+        return datetime(
+            self.year, self.month, day, 23, 59, 59, 999999, tzinfo=timezone.utc
+        )
 
 
 class WeekEvents(GenericPeriodEvents):
@@ -542,7 +548,10 @@ class WeekEvents(GenericPeriodEvents):
 
     @classmethod
     def from_date(
-        cls, event_name: str, dt: Optional[date | datetime] = None, system: str = "default"
+        cls,
+        event_name: str,
+        dt: Optional[date | datetime] = None,
+        system: str = "default",
     ):
         dt = dt or datetime.now(tz=timezone.utc)
         dt_year, dt_week, _ = dt.isocalendar()
@@ -581,7 +590,9 @@ class DayEvents(GenericPeriodEvents):
     """
 
     @classmethod
-    def from_date(cls, event_name: str, dt: Optional[date | datetime] = None, system="default"):
+    def from_date(
+        cls, event_name: str, dt: Optional[date | datetime] = None, system="default"
+    ):
         dt = dt or datetime.now(tz=timezone.utc)
         return cls(event_name, dt.year, dt.month, dt.day, system=system)
 
@@ -602,7 +613,9 @@ class DayEvents(GenericPeriodEvents):
         return datetime(self.year, self.month, self.day, tzinfo=timezone.utc)
 
     def period_end(self) -> datetime:
-        return datetime(self.year, self.month, self.day, 23, 59, 59, 999999, tzinfo=timezone.utc)
+        return datetime(
+            self.year, self.month, self.day, 23, 59, 59, 999999, tzinfo=timezone.utc
+        )
 
 
 class HourEvents(GenericPeriodEvents):
@@ -642,7 +655,9 @@ class HourEvents(GenericPeriodEvents):
         )
 
     def delta(self, value):
-        dt = datetime(self.year, self.month, self.day, self.hour, tzinfo=timezone.utc) + timedelta(hours=value)
+        dt = datetime(
+            self.year, self.month, self.day, self.hour, tzinfo=timezone.utc
+        ) + timedelta(hours=value)
         return self.__class__(
             self.event_name, dt.year, dt.month, dt.day, dt.hour, self.system
         )
@@ -651,7 +666,16 @@ class HourEvents(GenericPeriodEvents):
         return datetime(self.year, self.month, self.day, self.hour, tzinfo=timezone.utc)
 
     def period_end(self) -> datetime:
-        return datetime(self.year, self.month, self.day, self.hour, 59, 59, 999999, tzinfo=timezone.utc)
+        return datetime(
+            self.year,
+            self.month,
+            self.day,
+            self.hour,
+            59,
+            59,
+            999999,
+            tzinfo=timezone.utc,
+        )
 
 
 # --- Bit operations

--- a/bitmapist/cohort/__init__.py
+++ b/bitmapist/cohort/__init__.py
@@ -62,7 +62,7 @@ Get the data and render it via HTML::
 :license: BSD
 """
 
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from os import path
 from typing import Any, Callable, Literal, Optional, Union
 
@@ -228,10 +228,10 @@ def get_dates_data(
     num_of_rows = int(num_of_rows)
 
     if start_date:
-        now = datetime.strptime(start_date, "%Y-%m-%d")
+        now = datetime.strptime(start_date, "%Y-%m-%d").replace(tzinfo=timezone.utc)
         now = now + timedelta(days=num_results - 1)
     else:
-        now = datetime.utcnow()
+        now = datetime.now(tz=timezone.utc)
 
     # Days
     if time_group == "days":

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from bitmapist import delete_all_events, setup_redis
 
 
-@pytest.yield_fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session", autouse=True)
 def redis_server():
     """Fixture starting the Redis server"""
     redis_host = "127.0.0.1"

--- a/test/test_bitmapist.py
+++ b/test/test_bitmapist.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from bitmapist import (
     BitOpAnd,
@@ -17,7 +17,7 @@ from bitmapist import (
 def test_mark_with_diff_days():
     mark_event("active", 123, track_hourly=True)
 
-    now = datetime.utcnow()
+    now = datetime.now(tz=timezone.utc)
 
     # Month
     assert 123 in MonthEvents("active", now.year, now.month)
@@ -38,7 +38,7 @@ def test_mark_with_diff_days():
 
 
 def test_mark_unmark():
-    now = datetime.utcnow()
+    now = datetime.now(tz=timezone.utc)
 
     mark_event("active", 125)
     assert 125 in MonthEvents("active", now.year, now.month)
@@ -48,7 +48,7 @@ def test_mark_unmark():
 
 
 def test_mark_counts():
-    now = datetime.utcnow()
+    now = datetime.now(tz=timezone.utc)
 
     assert MonthEvents("active", now.year, now.month).get_count() == 0
 
@@ -59,7 +59,7 @@ def test_mark_counts():
 
 
 def test_mark_iter():
-    now = datetime.utcnow()
+    now = datetime.now(tz=timezone.utc)
     ev = MonthEvents("active", now.year, now.month)
 
     assert list(ev) == []
@@ -73,7 +73,7 @@ def test_mark_iter():
 
 
 def test_different_dates():
-    now = datetime.utcnow()
+    now = datetime.now(tz=timezone.utc)
     yesterday = now - timedelta(days=1)
 
     mark_event("active", 123, now=now)
@@ -88,7 +88,7 @@ def test_different_dates():
 
 
 def test_different_buckets():
-    now = datetime.utcnow()
+    now = datetime.now(tz=timezone.utc)
 
     mark_event("active", 123)
     mark_event("tasks:completed", 23232)
@@ -98,8 +98,8 @@ def test_different_buckets():
 
 
 def test_bit_operations():
-    now = datetime.utcnow()
-    last_month = datetime.utcnow() - timedelta(days=30)
+    now = datetime.now(tz=timezone.utc)
+    last_month = now - timedelta(days=30)
 
     # 123 has been active for two months
     mark_event("active", 123, now=now)
@@ -156,7 +156,7 @@ def test_bit_operations():
 
 
 def test_bit_operations_complex():
-    now = datetime.utcnow()
+    now = datetime.now(tz=timezone.utc)
     tom = now + timedelta(days=1)
 
     mark_event("task1", 111, now=now)
@@ -185,7 +185,7 @@ def test_bit_operations_complex():
 
 
 def test_bitop_key_sharing():
-    today = datetime.utcnow()
+    today = datetime.now(tz=timezone.utc)
 
     mark_event("task1", 111, now=today)
     mark_event("task2", 111, now=today)
@@ -207,7 +207,7 @@ def test_bitop_key_sharing():
 
 
 def test_events_marked():
-    now = datetime.utcnow()
+    now = datetime.now(tz=timezone.utc)
 
     assert MonthEvents("active", now.year, now.month).get_count() == 0
     assert MonthEvents("active", now.year, now.month).has_events_marked() is False

--- a/test/test_cohort.py
+++ b/test/test_cohort.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -8,7 +8,7 @@ from bitmapist.cohort import get_dates_data
 
 @pytest.fixture
 def events():
-    today = datetime.utcnow()
+    today = datetime.now(tz=timezone.utc)
     tomorrow = today + timedelta(days=1)
 
     mark_event("signup", 111, now=today)

--- a/test/test_from_date.py
+++ b/test/test_from_date.py
@@ -4,30 +4,40 @@ import bitmapist
 
 
 def test_from_date_year():
-    ev1 = bitmapist.YearEvents.from_date("foo", datetime(2014, 1, 1, tzinfo=timezone.utc))
+    ev1 = bitmapist.YearEvents.from_date(
+        "foo", datetime(2014, 1, 1, tzinfo=timezone.utc)
+    )
     ev2 = bitmapist.YearEvents("foo", 2014)
     assert ev1 == ev2
 
 
 def test_from_date_month():
-    ev1 = bitmapist.MonthEvents.from_date("foo", datetime(2014, 1, 1, tzinfo=timezone.utc))
+    ev1 = bitmapist.MonthEvents.from_date(
+        "foo", datetime(2014, 1, 1, tzinfo=timezone.utc)
+    )
     ev2 = bitmapist.MonthEvents("foo", 2014, 1)
     assert ev1 == ev2
 
 
 def test_from_date_week():
-    ev1 = bitmapist.MonthEvents.from_date("foo", datetime(2014, 1, 1, tzinfo=timezone.utc))
+    ev1 = bitmapist.MonthEvents.from_date(
+        "foo", datetime(2014, 1, 1, tzinfo=timezone.utc)
+    )
     ev2 = bitmapist.MonthEvents("foo", 2014, 1)
     assert ev1 == ev2
 
 
 def test_from_date_day():
-    ev1 = bitmapist.DayEvents.from_date("foo", datetime(2014, 1, 1, tzinfo=timezone.utc))
+    ev1 = bitmapist.DayEvents.from_date(
+        "foo", datetime(2014, 1, 1, tzinfo=timezone.utc)
+    )
     ev2 = bitmapist.DayEvents("foo", 2014, 1, 1)
     assert ev1 == ev2
 
 
 def test_from_date_hour():
-    ev1 = bitmapist.HourEvents.from_date("foo", datetime(2014, 1, 1, 1, tzinfo=timezone.utc))
+    ev1 = bitmapist.HourEvents.from_date(
+        "foo", datetime(2014, 1, 1, 1, tzinfo=timezone.utc)
+    )
     ev2 = bitmapist.HourEvents("foo", 2014, 1, 1, 1)
     assert ev1 == ev2

--- a/test/test_from_date.py
+++ b/test/test_from_date.py
@@ -1,33 +1,33 @@
-import datetime
+from datetime import datetime, timezone
 
 import bitmapist
 
 
 def test_from_date_year():
-    ev1 = bitmapist.YearEvents.from_date("foo", datetime.datetime(2014, 1, 1))
+    ev1 = bitmapist.YearEvents.from_date("foo", datetime(2014, 1, 1, tzinfo=timezone.utc))
     ev2 = bitmapist.YearEvents("foo", 2014)
     assert ev1 == ev2
 
 
 def test_from_date_month():
-    ev1 = bitmapist.MonthEvents.from_date("foo", datetime.datetime(2014, 1, 1))
+    ev1 = bitmapist.MonthEvents.from_date("foo", datetime(2014, 1, 1, tzinfo=timezone.utc))
     ev2 = bitmapist.MonthEvents("foo", 2014, 1)
     assert ev1 == ev2
 
 
 def test_from_date_week():
-    ev1 = bitmapist.MonthEvents.from_date("foo", datetime.datetime(2014, 1, 1))
+    ev1 = bitmapist.MonthEvents.from_date("foo", datetime(2014, 1, 1, tzinfo=timezone.utc))
     ev2 = bitmapist.MonthEvents("foo", 2014, 1)
     assert ev1 == ev2
 
 
 def test_from_date_day():
-    ev1 = bitmapist.DayEvents.from_date("foo", datetime.datetime(2014, 1, 1))
+    ev1 = bitmapist.DayEvents.from_date("foo", datetime(2014, 1, 1, tzinfo=timezone.utc))
     ev2 = bitmapist.DayEvents("foo", 2014, 1, 1)
     assert ev1 == ev2
 
 
 def test_from_date_hour():
-    ev1 = bitmapist.HourEvents.from_date("foo", datetime.datetime(2014, 1, 1, 1))
+    ev1 = bitmapist.HourEvents.from_date("foo", datetime(2014, 1, 1, 1, tzinfo=timezone.utc))
     ev2 = bitmapist.HourEvents("foo", 2014, 1, 1, 1)
     assert ev1 == ev2

--- a/test/test_period_start_end.py
+++ b/test/test_period_start_end.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -16,6 +16,6 @@ import bitmapist
     ],
 )
 def test_period_start_end(cls):
-    dt = datetime.datetime(2014, 1, 1, 8, 30)
+    dt = datetime(2014, 1, 1, 8, 30, tzinfo=timezone.utc)
     ev = cls.from_date("foo", dt)
     assert ev.period_start() <= dt <= ev.period_end()


### PR DESCRIPTION
Needed so we emit no warnings when running on python 3.12 systems.

AFAICT, these datetimes are mainly just used to determine redis keys, where the naive/aware makes no difference, and the previous "naive" datetimes were all implicitly UTC anyways (via `utcnow`).

However, this does change `period_start` and `period_end` to return aware datetimes, which is technically breaking!

If you folks notice anything beyond that, please let me know and I'll take a look 🙂 