### PR TITLE
Bump GitHub Action pins to node24-compatible majors

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
         backend: ['redis', 'bitmapist-server']
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
@@ -45,7 +45,7 @@ jobs:
       - name: Cache bitmapist-server
         if: matrix.backend == 'bitmapist-server'
         id: cache-bitmapist
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/bitmapist-server
           key: bitmapist-server-${{ steps.bitmapist-version.outputs.version }}


### PR DESCRIPTION
Bumps GitHub Action pins to majors that ship with the node24 runtime, ahead of GitHub's node20 deprecation.

- `actions/cache` v4 → v5

Tracking: https://github.com/Doist/platform-backlog/issues/1385
